### PR TITLE
refactor: use type guards instead of typeof checks in parsers.ts

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,9 +1,10 @@
 import { RenderFunction, StatelessComponentConfig, StyleFunction } from './model';
+import { isString, isUndefined } from './type-guards';
 
 /* SELECTOR */
 function parseSelector(configOrSelector, config) {
   const selector = config ? config.selector : (configOrSelector as string);
-  if (typeof selector === 'undefined') {
+  if (isUndefined(selector)) {
     throw Error('You should specify a selector.');
   }
   return selector;
@@ -11,12 +12,12 @@ function parseSelector(configOrSelector, config) {
 /* TEMPLATE */
 function parseTemplate(renderFnOrTemplate, config) {
   const template = renderFnOrTemplate
-    ? typeof renderFnOrTemplate === 'string'
+    ? isString(renderFnOrTemplate)
       ? renderFnOrTemplate
       : renderFnOrTemplate()
     : config.template;
 
-  if (typeof template === 'undefined') {
+  if (isUndefined(template)) {
     throw Error('You should specify a template.');
   }
   return template;
@@ -24,7 +25,11 @@ function parseTemplate(renderFnOrTemplate, config) {
 
 /* STYLE */
 function parseStyle(styleFnOrStyle, config) {
-  return styleFnOrStyle ? (typeof styleFnOrStyle === 'string' ? [styleFnOrStyle] : [styleFnOrStyle()]) : [config.style];
+  return styleFnOrStyle
+    ? (isString(styleFnOrStyle)
+      ? [styleFnOrStyle]
+      : [styleFnOrStyle()])
+    : [config.style];
 }
 
 /* INPUTS/OUTPUTS */
@@ -68,8 +73,7 @@ export function parse(
   renderFnOrTemplate?: RenderFunction | string,
   styleFnOrStyle?: string | StyleFunction,
 ): ParseResult {
-  const config: StatelessComponentConfig =
-    typeof configOrSelector !== 'string' && (configOrSelector as StatelessComponentConfig);
+  const config: StatelessComponentConfig = !isString(configOrSelector) && configOrSelector;
 
   return {
     selector: parseSelector(configOrSelector, config),

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,9 +1,9 @@
 import { RenderFunction, StatelessComponentConfig, StyleFunction } from './model';
-import { isString, isUndefined } from './type-guards';
+import { isDefined, isString, isUndefined } from './type-guards';
 
 /* SELECTOR */
 function parseSelector(configOrSelector, config) {
-  const selector = config ? config.selector : (configOrSelector as string);
+  const selector = isDefined(config) ? config.selector : (configOrSelector as string);
   if (isUndefined(selector)) {
     throw Error('You should specify a selector.');
   }
@@ -11,7 +11,7 @@ function parseSelector(configOrSelector, config) {
 }
 /* TEMPLATE */
 function parseTemplate(renderFnOrTemplate, config) {
-  const template = renderFnOrTemplate
+  const template = isDefined(renderFnOrTemplate)
     ? isString(renderFnOrTemplate)
       ? renderFnOrTemplate
       : renderFnOrTemplate()
@@ -25,16 +25,16 @@ function parseTemplate(renderFnOrTemplate, config) {
 
 /* STYLE */
 function parseStyle(styleFnOrStyle, config) {
-  return styleFnOrStyle
-    ? (isString(styleFnOrStyle)
+  return isDefined(styleFnOrStyle)
+    ? isString(styleFnOrStyle)
       ? [styleFnOrStyle]
-      : [styleFnOrStyle()])
+      : [styleFnOrStyle()]
     : [config.style];
 }
 
 /* INPUTS/OUTPUTS */
 function parseInputsOutputs(inOut, config) {
-  if (inOut || config.inOut) {
+  if (isDefined(inOut) || isDefined(config.inOut)) {
     const tmpInOut = config.inOut || inOut || [];
     const sortedInOut = tmpInOut
       .reduce(

--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -1,0 +1,7 @@
+export function isString(x: unknown): x is string {
+  return typeof x === 'string' || Object.prototype.toString.call(x) === '[object String]';
+}
+
+export function isUndefined(x: unknown): x is undefined {
+  return typeof x === 'undefined';
+}

--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -5,3 +5,7 @@ export function isString(x: unknown): x is string {
 export function isUndefined(x: unknown): x is undefined {
   return typeof x === 'undefined';
 }
+
+export function isDefined<T>(x: T | null | undefined): x is T {
+  return typeof x !== 'undefined';
+}


### PR DESCRIPTION
Replace typeof checks using type guards in parsers.ts
Resolve #1 